### PR TITLE
added filter parameter to GetSignedAuditEvents

### DIFF
--- a/src/schema/fd/phr/AccountManagementService.xsd
+++ b/src/schema/fd/phr/AccountManagementService.xsd
@@ -124,12 +124,58 @@
 		</xs:complexType>
 	</xs:element>
 	<xs:element name="GetSignedAuditEventsRequest">
-		<xs:complexType/>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="PageSize" minOccurs="0">
+					<xs:simpleType>
+						<xs:restriction base="xs:integer">
+							<xs:minInclusive value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="PageNumber" minOccurs="0">
+					<xs:simpleType>
+						<xs:restriction base="xs:integer">
+							<xs:minInclusive value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="LastDay" type="xs:date" minOccurs="0"/>
+			</xs:sequence>
+		</xs:complexType>
 	</xs:element>
 	<xs:element name="GetSignedAuditEventsResponse">
 		<xs:complexType>
 			<xs:sequence>
 				<xs:element name="SignedAuditEventList" type="xs:base64Binary"/>
+				<xs:element name="PageSize" minOccurs="0">
+					<xs:simpleType>
+						<xs:restriction base="xs:integer">
+							<xs:minInclusive value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="PageNumber" minOccurs="0">
+					<xs:simpleType>
+						<xs:restriction base="xs:integer">
+							<xs:minInclusive value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="TotalPages" minOccurs="0">
+					<xs:simpleType>
+						<xs:restriction base="xs:integer">
+							<xs:minInclusive value="0"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="TotalEntries" minOccurs="0">
+					<xs:simpleType>
+						<xs:restriction base="xs:integer">
+							<xs:minInclusive value="0"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>

--- a/src/schema/fd/phr/AuthenticationService.xsd
+++ b/src/schema/fd/phr/AuthenticationService.xsd
@@ -89,12 +89,58 @@
 		</complexType>
 	</element>
 	<element name="GetSignedAuditEvents">
-		<complexType/>
+		<complexType>
+			<sequence>
+				<element name="PageSize" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="1"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="PageNumber" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="1"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="LastDay" type="date" minOccurs="0"/>
+			</sequence>
+		</complexType>
 	</element>
 	<element name="GetSignedAuditEventsResponse">
 		<complexType>
 			<sequence>
 				<element name="SignedAuditEventList" type="base64Binary"/>
+				<element name="PageSize" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="1"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="PageNumber" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="1"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="TotalPages" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="0"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="TotalEntries" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="0"/>
+						</restriction>
+					</simpleType>
+				</element>
 			</sequence>
 		</complexType>
 	</element>

--- a/src/schema/fd/phr/AuthorizationService.xsd
+++ b/src/schema/fd/phr/AuthorizationService.xsd
@@ -254,6 +254,21 @@
 			<sequence>
 				<element name="RecordIdentifier" type="phr:RecordIdentifierType"/>
 				<element name="DeviceID" type="phr:DeviceIdType"/>
+				<element name="PageSize" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="1"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="PageNumber" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="1"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="LastDay" type="date" minOccurs="0"/>
 			</sequence>
 		</complexType>
 	</element>
@@ -261,6 +276,34 @@
 		<complexType>
 			<sequence>
 				<element name="SignedAuditEventList" type="base64Binary"/>
+				<element name="PageSize" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="1"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="PageNumber" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="1"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="TotalPages" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="0"/>
+						</restriction>
+					</simpleType>
+				</element>
+				<element name="TotalEntries" minOccurs="0">
+					<simpleType>
+						<restriction base="integer">
+							<minInclusive value="0"/>
+						</restriction>
+					</simpleType>
+				</element>
 			</sequence>
 		</complexType>
 	</element>


### PR DESCRIPTION
**Context:**
Paging and filter parameters have been added to the interface "Operation getAuditEvents", which is described e.g. in A_14477-02. This makes it possible to transfer a large number of entries in a resource-saving way or to transfer a smaller number of entries.

**Actual:**
Currently, no paging and filter parameters are specified in the "Operation getSignedAuditEvents" interface (e.g. A_21162-01). 

**Expected:**
We expect the same requirements for filtering and paging to exist in the "Operation getSignedAuditEvents" interface, which is described, for example, in A_21162-01. The interface "Operation getSignedAuditEvents" is just a signed version of the interface "Operation getAuditEvents".

**Solution / Suggestion:**
We added the paging and filter parameters as defined in the interface "Operation getAuditEvents" to the interface "Operation getSignedAuditEvents". See changed sources.